### PR TITLE
Removing key prefixes when using XMLDictionaryAttributesModeDiscard

### DIFF
--- a/XMLDictionary/XMLDictionary.m
+++ b/XMLDictionary/XMLDictionary.m
@@ -201,6 +201,13 @@
 {	
 	[self endText];
 	
+	if (_attributesMode==XMLDictionaryAttributesModeDiscard) {
+		NSUInteger loc = [elementName rangeOfString:@":"].location;
+		if (loc != NSNotFound) {
+			elementName = [elementName substringFromIndex:loc + 1];
+		}
+	}
+	
 	NSMutableDictionary *node = [NSMutableDictionary dictionary];
 	switch (_nodeNameMode)
 	{


### PR DESCRIPTION
Should resolve https://github.com/nicklockwood/XMLDictionary/issues/19
