### PR TITLE
fixed a naming conflict

### DIFF
--- a/XMLDictionary/XMLDictionary.h
+++ b/XMLDictionary/XMLDictionary.h
@@ -93,7 +93,7 @@ static NSString *const XMLDictionaryAttributePrefix = @"_";
 - (NSString *)nodeName;
 - (NSString *)innerText;
 - (NSString *)innerXML;
-- (NSString *)XMLString;
+- (NSString *)XMLDictionaryString;
 
 - (NSArray *)arrayValueForKeyPath:(NSString *)keyPath;
 - (NSString *)stringValueForKeyPath:(NSString *)keyPath;

--- a/XMLDictionary/XMLDictionary.m
+++ b/XMLDictionary/XMLDictionary.m
@@ -492,7 +492,7 @@
 	return [nodes componentsJoinedByString:@"\n"];
 }
 
-- (NSString *)XMLString
+- (NSString *)XMLDictionaryString
 {
     if ([self count] == 1 && ![self nodeName])
     {


### PR DESCRIPTION
Apparently Apple also has a method named:
- (NSString *)XMLString

this can cause many many issues….

many thanks to:
https://github.com/azplanlos
